### PR TITLE
GHA Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Some repositories won't need to build and publish a Docker image, this flag allo
 
 ```yaml
 with:
-  skip_docker: 'true'
+  skip_docker: true
 ```
 
 #### Docker Directory
@@ -134,7 +134,7 @@ Sometimes when trying to debug a k8s deployment that refuses to deploy correctly
 
 ```yaml
 with:
-  skip_deploy_status: 'true'
+  skip_deploy_status: true
 ```
 
 #### Print Environment Variables
@@ -145,7 +145,7 @@ Sometimes it is helpful to view the environment variables set to help debug. Sup
 
 ```yaml
 with:
-  print_environemnt: 'true'
+  print_environemnt: true
 ```
 
 #### Print GCloud Info
@@ -156,5 +156,5 @@ Sometimes it is helpful to view gcloud information to help debug. Supplying this
 
 ```yaml
 with:
-  print_gcloud_info: 'true'
+  print_gcloud_info: true
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The purpose of this GitHub Action is to handle the setup of GCloud and kubectl r
 
 #### K8S Directory
 
-Used to specify a different directory to check for k8s related config files. All k8s files to deploy my be under this directory.
+Used to specify a different directory to check for k8s related config files. All k8s files to deploy may be under this directory.
 
 > Example kubernetes configs can be found under the `k8s` directory. These are not used within this GitHub Action.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The purpose of this GitHub Action is to handle the setup of GCloud and kubectl r
 
 - name: Deploy Kubernetes
   uses: dmsi-io/gha-k8s-deploy@v1
-  with: 
+  with:
     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
     GKE_CLUSTER_NAME: ${{ secrets.GCP_STAGING_CLUSTER_NAME }}
     GCP_ZONE: ${{ secrets.GCP_ZONE }}
@@ -26,80 +26,80 @@ The purpose of this GitHub Action is to handle the setup of GCloud and kubectl r
 ### Optional inputs
 
 #### K8S Directory
- 
-Used to specify a different directory to check for k8s related config files. All k8s files to deploy my be under this directory. 
+
+Used to specify a different directory to check for k8s related config files. All k8s files to deploy my be under this directory.
 
 > Example kubernetes configs can be found under the `k8s` directory. These are not used within this GitHub Action.
 
 - Default: `k8s`
 
 ```yaml
-  with:
-    k8s_directory: 'kubernetes'
+with:
+  k8s_directory: 'kubernetes'
 ```
 
 #### Namespace
- 
+
 Used to specify a different file to deploy a Namespace object from. If the file does not exist, it will not try to deploy.
 
 - Default: `namespace.yaml`
 
 ```yaml
-  with:
-    namespace: 'name.yaml'
+with:
+  namespace: 'name.yaml'
 ```
 
 #### Secret
- 
+
 Used to specify a secret to copy from the default namespace into the namespace being created.
 
 ```yaml
-  with:
-    secret: 'secret-env'
+with:
+  secret: 'secret-env'
 ```
 
 #### ConfigMap
- 
+
 Used to specify a different file to deploy a ConfigMap object from. If the file does not exist, it will not try to deploy.
 
 - Default: `configmap.yaml`
 
 ```yaml
-  with:
-    configmap: 'config.yaml'
+with:
+  configmap: 'config.yaml'
 ```
 
 #### Deployment
- 
+
 Used to specify a different file to deploy a Deployment object from. If the file does not exist, it will not try to deploy.
 
 - Default: `deployment.yaml`
 
 ```yaml
-  with:
-    deployment: 'deploy.yaml'
+with:
+  deployment: 'deploy.yaml'
 ```
 
 #### Service
- 
+
 Used to specify a different file to deploy a Service object from. If the file does not exist, it will not try to deploy.
 
 - Default: `service.yaml`
 
 ```yaml
-  with:
-    service: 'serv.yaml'
+with:
+  service: 'serv.yaml'
 ```
 
 #### Ingress
- 
+
 Used to specify a different file to deploy a Ingress object from. If the file does not exist, it will not try to deploy.
 
 - Default: `ingress.yaml`
 
 ```yaml
-  with:
-    ingress: 'ing.yaml'
+with:
+  ingress: 'ing.yaml'
 ```
 
 #### Skip Docker
@@ -109,8 +109,8 @@ Some repositories won't need to build and publish a Docker image, this flag allo
 - Default: `false`
 
 ```yaml
-  with:
-    skip_docker: 'true'
+with:
+  skip_docker: 'true'
 ```
 
 #### Docker Directory
@@ -120,8 +120,8 @@ Sometimes the Dockerfile will not be located at the head of a repository, this i
 - Default: `./`
 
 ```yaml
-  with:
-    docker_directory: '.docker'
+with:
+  docker_directory: '.docker'
 ```
 
 #### Skip Deployment Status
@@ -133,6 +133,28 @@ Sometimes when trying to debug a k8s deployment that refuses to deploy correctly
 - Default: `false`
 
 ```yaml
-  with:
-    skip_deploy_status: 'true'
+with:
+  skip_deploy_status: 'true'
+```
+
+#### Print Environment Variables
+
+Sometimes it is helpful to view the environment variables set to help debug. Supplying this flag will print `env | sort` to the console.
+
+- Default: `false`
+
+```yaml
+with:
+  print_environemnt: 'true'
+```
+
+#### Print GCloud Info
+
+Sometimes it is helpful to view gcloud information to help debug. Supplying this flag will print out `gcloud info` after authenticating.
+
+- Default: `false`
+
+```yaml
+with:
+  print_gcloud_info: 'true'
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ with:
   namespace: 'name.yaml'
 ```
 
+> If deploying a namespace, the created domain can be accessed via: (id: deploy) `${{ steps.deploy.outputs.url }}`
+
 #### Secret
 
 Used to specify a secret to copy from the default namespace into the namespace being created.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Sometimes it is helpful to view the environment variables set to help debug. Sup
 
 ```yaml
 with:
-  print_environemnt: true
+  print_environment: true
 ```
 
 #### Print GCloud Info

--- a/README.md
+++ b/README.md
@@ -15,12 +15,28 @@ The purpose of this GitHub Action is to handle the setup of GCloud and kubectl r
     GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
 - name: Deploy Kubernetes
-  uses: dmsi-io/gha-k8s-deploy@v1
+  uses: dmsi-io/gha-k8s-deploy@v1.1
   with:
     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
     GKE_CLUSTER_NAME: ${{ secrets.GCP_STAGING_CLUSTER_NAME }}
     GCP_ZONE: ${{ secrets.GCP_ZONE }}
     GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+```
+
+### Outputs
+
+#### URL
+
+If deploying a new namespace, this action will output the full URL of the new namespace
+
+```yaml
+- name: Deploy Kubernetes
+  uses: dmsi-io/gha-k8s-deploy@v1.1
+  id: deploy
+  with: ...
+
+- name: Print URL
+  run: echo ${{ steps.deploy.outputs.url }}
 ```
 
 ### Optional inputs
@@ -48,8 +64,6 @@ Used to specify a different file to deploy a Namespace object from. If the file 
 with:
   namespace: 'name.yaml'
 ```
-
-> If deploying a namespace, the created domain can be accessed via: (id: deploy) `${{ steps.deploy.outputs.url }}`
 
 #### Secret
 

--- a/action.yaml
+++ b/action.yaml
@@ -77,7 +77,12 @@ inputs:
     required: false
     default: 'false'
 
-runs:
+outputs:
+  url:
+    description: 'URL'
+    value: ${{ steps.URL.outputs.URL }}
+
+runs: 
   using: 'composite'
   steps:
     - name: environment
@@ -164,6 +169,12 @@ runs:
         cat ${{ inputs.namespace }} | envsubst | kubectl apply -f -
       shell: bash
       working-directory: ${{ inputs.k8s_directory }}
+
+    - name: Output URL
+      id: URL
+      if: steps.namespace_exists.outputs.files_exists == 'true'
+      run: echo "::set-output name=URL::https://$HOSTNAME"
+      shell: bash
 
     - name: Copy secret to namespace
       if: inputs.secret != ''

--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,7 @@ name: 'Deploy Kubernetes Application'
 description: 'Used to handle the gcloud and kubectl setup to deploy Docker images to Google Container Registry and deploy an application to the Kubernetes cluster.'
 
 inputs:
-  GCP_SA_KEY: 
+  GCP_SA_KEY:
     description: 'GCP Service Account Key (JSON)'
     required: true
 
@@ -10,7 +10,7 @@ inputs:
     description: 'Google Kubernetes Engine Cluster name'
     required: true
 
-  GCP_ZONE: 
+  GCP_ZONE:
     description: 'GCP Zone'
     required: true
 
@@ -18,7 +18,7 @@ inputs:
     description: 'GCP Project ID'
     required: true
 
-  k8s_directory: 
+  k8s_directory:
     description: 'Location of k8s config files'
     required: false
     default: 'k8s'
@@ -61,52 +61,46 @@ inputs:
     description: 'Directory of Dockerfile'
     required: false
     default: './'
-    
+
   skip_deploy_status:
     description: 'Flag to skip deployment status check'
     required: false
     default: 'false'
 
-runs: 
+runs:
   using: 'composite'
   steps:
-    - name: Environment
-      run: |
-        env | sort
-        sudo apt-get install gettext
-      shell: bash
-
     ####### Check file existence #######
 
-    - name: "Check namespace existence"
+    - name: 'Check namespace existence'
       id: namespace_exists
       uses: andstor/file-existence-action@v1.0.1
       with:
-        files: "${{ inputs.k8s_directory }}/${{ inputs.namespace }}"
-    
-    - name: "Check configmap existence"
+        files: '${{ inputs.k8s_directory }}/${{ inputs.namespace }}'
+
+    - name: 'Check configmap existence'
       id: configmap_exists
       uses: andstor/file-existence-action@v1.0.1
       with:
-        files: "${{ inputs.k8s_directory }}/${{ inputs.configmap }}"
+        files: '${{ inputs.k8s_directory }}/${{ inputs.configmap }}'
 
-    - name: "Check deployment existence"
+    - name: 'Check deployment existence'
       id: deployment_exists
       uses: andstor/file-existence-action@v1.0.1
       with:
-        files: "${{ inputs.k8s_directory }}/${{ inputs.deployment }}"
+        files: '${{ inputs.k8s_directory }}/${{ inputs.deployment }}'
 
-    - name: "Check service existence"
+    - name: 'Check service existence'
       id: service_exists
       uses: andstor/file-existence-action@v1.0.1
       with:
-        files: "${{ inputs.k8s_directory }}/${{ inputs.service }}"
+        files: '${{ inputs.k8s_directory }}/${{ inputs.service }}'
 
-    - name: "Check ingress existence"
+    - name: 'Check ingress existence'
       id: ingress_exists
       uses: andstor/file-existence-action@v1.0.1
       with:
-        files: "${{ inputs.k8s_directory }}/${{ inputs.ingress }}"
+        files: '${{ inputs.k8s_directory }}/${{ inputs.ingress }}'
 
     ###### GCloud Setup ######
 
@@ -151,7 +145,7 @@ runs:
       if: steps.namespace_exists.outputs.files_exists == 'true'
       run: |
         cat ${{ inputs.namespace }} | envsubst
-        cat ${{ inputs.namespace }} | envsubst | kubectl apply -f - 
+        cat ${{ inputs.namespace }} | envsubst | kubectl apply -f -
       shell: bash
       working-directory: ${{ inputs.k8s_directory }}
 
@@ -176,7 +170,7 @@ runs:
       if: steps.configmap_exists.outputs.files_exists == 'true'
       run: |
         cat ${{ inputs.configmap }} | envsubst
-        cat ${{ inputs.configmap }} | envsubst | kubectl apply -n $NAMESPACE -f - 
+        cat ${{ inputs.configmap }} | envsubst | kubectl apply -n $NAMESPACE -f -
       shell: bash
       working-directory: ${{ inputs.k8s_directory }}
 

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: 'false'
 
-  print_environemnt:
+  print_environment:
     description: 'Flag to optionally print environment variables'
     required: false
     default: 'false'
@@ -81,7 +81,7 @@ runs:
   using: 'composite'
   steps:
     - name: environment
-      if: inputs.print_environemnt == 'true'
+      if: inputs.print_environment == 'true'
       run: env | sort
       shell: bash
 

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,16 @@ inputs:
     description: 'GCP Project ID'
     required: true
 
+  print_gcloud_info:
+    description: 'Flag to optionally print gcloud info after authenticating'
+    required: false
+    default: 'false'
+
+  print_environemnt:
+    description: 'Flag to optionally print environment variables'
+    required: false
+    default: 'false'
+
   k8s_directory:
     description: 'Location of k8s config files'
     required: false
@@ -70,6 +80,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: environment
+      if: inputs.print_environemnt == 'true'
+      run: env | sort
+      shell: bash
+
     ####### Check file existence #######
 
     - name: 'Check namespace existence'
@@ -114,6 +129,7 @@ runs:
       uses: google-github-actions/setup-gcloud@v0.2.1
 
     - name: Use gcloud CLI
+      if: inputs.print_gcloud_info == 'true'
       run: gcloud info
       shell: bash
 


### PR DESCRIPTION
## 📑 Description
Turning off `gcloud info` and `env | sort` print outs to remove extra clutter from GHA usage. These can now optionally be turned back on via inputs.
