### PR TITLE
Deploy Develop/Latest Tags on respective runs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -168,9 +168,21 @@ runs:
       working-directory: ${{ inputs.docker_directory }}
       shell: bash
 
-    - name: Publish
+    - name: Deploy Develop Image
+      if: inputs.skip_docker != 'true' #&& github.ref_name == 'develop'
+      run: |
+        docker image tag $BUILD_IMAGE "${BUILD_IMAGE%:*}:develop"
+      shell: bash
+
+    - name: Deploy Latest Image
+      if: inputs.skip_docker != 'true' #&& github.ref_type == 'tag'
+      run: |
+        docker image tag $BUILD_IMAGE "${BUILD_IMAGE%:*}:latest"
+      shell: bash
+
+    - name: Publish Tags
       if: inputs.skip_docker != 'true'
-      run: docker push $BUILD_IMAGE
+      run: docker image push --all-tags ${BUILD_IMAGE%:*}
       shell: bash
 
     ###### Deploy Kubernetes Artifacts ######

--- a/action.yaml
+++ b/action.yaml
@@ -169,13 +169,13 @@ runs:
       shell: bash
 
     - name: Deploy Develop Image
-      if: inputs.skip_docker != 'true' #&& github.ref_name == 'develop'
+      if: inputs.skip_docker != 'true' && github.ref_name == 'develop'
       run: |
         docker image tag $BUILD_IMAGE "${BUILD_IMAGE%:*}:develop"
       shell: bash
 
     - name: Deploy Latest Image
-      if: inputs.skip_docker != 'true' #&& github.ref_type == 'tag'
+      if: inputs.skip_docker != 'true' && github.ref_type == 'tag'
       run: |
         docker image tag $BUILD_IMAGE "${BUILD_IMAGE%:*}:latest"
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -168,13 +168,13 @@ runs:
       working-directory: ${{ inputs.docker_directory }}
       shell: bash
 
-    - name: Deploy Develop Image
+    - name: Create Develop Image
       if: inputs.skip_docker != 'true' && github.ref_name == 'develop'
       run: |
         docker image tag $BUILD_IMAGE "${BUILD_IMAGE%:*}:develop"
       shell: bash
 
-    - name: Deploy Latest Image
+    - name: Create Latest Image
       if: inputs.skip_docker != 'true' && github.ref_type == 'tag'
       run: |
         docker image tag $BUILD_IMAGE "${BUILD_IMAGE%:*}:latest"


### PR DESCRIPTION
## 📑 Description
This change was inspired by a conversation with @tmclnk about how we don't have a `latest` or `develop` image anywhere in GCR. This change will make it so when we push to a `develop` branch or release a new tagged version, a duplicate of the image will be published with `develop` and `latest` tags respectively.

This will make it easier to pull the most recent images to your local machine by simply referencing the `develop` or `latest` tags.

Workflow run deploying all images (i.e. conditions commented out): https://github.com/dmsi-io/session-api/runs/6514784164?check_suite_focus=true

Workflow run deploying only commit sha image: https://github.com/dmsi-io/session-api/runs/6514825529?check_suite_focus=true